### PR TITLE
Support custom http.Client

### DIFF
--- a/ethrpc.go
+++ b/ethrpc.go
@@ -37,13 +37,29 @@ type ethRequest struct {
 // EthRPC - Ethereum rpc client
 type EthRPC struct {
 	url    string
-	client http.Client
-	Debug  bool
+	client httpClient
+	debug  bool
+}
+
+func Client(client httpClient) func(rpc *EthRPC) {
+	return func(rpc *EthRPC) {
+		rpc.client = client
+	}
+}
+
+func Debug(isEnabled bool) func(rpc *EthRPC) {
+	return func(rpc *EthRPC) {
+		rpc.debug = isEnabled
+	}
 }
 
 // NewEthRPC create new rpc client with given url
-func NewEthRPC(url string, client http.Client) *EthRPC {
-	return &EthRPC{url: url, client: client}
+func NewEthRPC(url string, options ...func(rpc *EthRPC)) *EthRPC {
+	rpc := &EthRPC{url: url, client: &http.Client{}}
+	for _, option := range options {
+		option(rpc)
+	}
+	return rpc
 }
 
 func (rpc *EthRPC) call(method string, target interface{}, params ...interface{}) error {

--- a/ethrpc.go
+++ b/ethrpc.go
@@ -37,19 +37,19 @@ type ethRequest struct {
 // EthRPC - Ethereum rpc client
 type EthRPC struct {
 	url    string
-	client httpClient
+	client HttpClient
 	debug  bool
 }
 
-func Client(client httpClient) func(rpc *EthRPC) {
+func Client(client HttpClient) func(rpc *EthRPC) {
 	return func(rpc *EthRPC) {
 		rpc.client = client
 	}
 }
 
-func Debug(isEnabled bool) func(rpc *EthRPC) {
+func Debug(enabled bool) func(rpc *EthRPC) {
 	return func(rpc *EthRPC) {
-		rpc.debug = isEnabled
+		rpc.debug = enabled
 	}
 }
 

--- a/ethrpc.go
+++ b/ethrpc.go
@@ -36,13 +36,14 @@ type ethRequest struct {
 
 // EthRPC - Ethereum rpc client
 type EthRPC struct {
-	url   string
-	Debug bool
+	url    string
+	client http.Client
+	Debug  bool
 }
 
 // NewEthRPC create new rpc client with given url
-func NewEthRPC(url string) *EthRPC {
-	return &EthRPC{url: url}
+func NewEthRPC(url string, client http.Client) *EthRPC {
+	return &EthRPC{url: url, client: client}
 }
 
 func (rpc *EthRPC) call(method string, target interface{}, params ...interface{}) error {
@@ -76,7 +77,7 @@ func (rpc *EthRPC) Call(method string, params ...interface{}) (json.RawMessage, 
 		return nil, err
 	}
 
-	response, err := http.Post(rpc.url, "application/json", bytes.NewBuffer(body))
+	response, err := rpc.client.Post(rpc.url, "application/json", bytes.NewBuffer(body))
 	if response != nil {
 		defer response.Body.Close()
 	}

--- a/ethrpc.go
+++ b/ethrpc.go
@@ -38,7 +38,7 @@ type ethRequest struct {
 type EthRPC struct {
 	url    string
 	client HttpClient
-	debug  bool
+	Debug  bool
 }
 
 func Client(client HttpClient) func(rpc *EthRPC) {
@@ -49,7 +49,7 @@ func Client(client HttpClient) func(rpc *EthRPC) {
 
 func Debug(enabled bool) func(rpc *EthRPC) {
 	return func(rpc *EthRPC) {
-		rpc.debug = enabled
+		rpc.Debug = enabled
 	}
 }
 

--- a/ethrpc_test.go
+++ b/ethrpc_test.go
@@ -60,8 +60,7 @@ func (s *EthRPCTestSuite) paramsEqual(body []byte, expected string) {
 }
 
 func (s *EthRPCTestSuite) SetupSuite() {
-	s.rpc = NewEthRPC("http://127.0.0.1:8545", http.Client{})
-	// s.rpc.Debug = true
+	s.rpc = NewEthRPC("http://127.0.0.1:8545", Client(&http.Client{}), Debug(false))
 
 	httpmock.Activate()
 }

--- a/ethrpc_test.go
+++ b/ethrpc_test.go
@@ -60,7 +60,7 @@ func (s *EthRPCTestSuite) paramsEqual(body []byte, expected string) {
 }
 
 func (s *EthRPCTestSuite) SetupSuite() {
-	s.rpc = NewEthRPC("http://127.0.0.1:8545")
+	s.rpc = NewEthRPC("http://127.0.0.1:8545", http.Client{})
 	// s.rpc.Debug = true
 
 	httpmock.Activate()

--- a/types.go
+++ b/types.go
@@ -3,7 +3,9 @@ package ethrpc
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"math/big"
+	"net/http"
 	"unsafe"
 )
 
@@ -317,4 +319,8 @@ func (proxy *proxyBlockWithoutTransactions) toBlock() Block {
 	}
 
 	return block
+}
+
+type httpClient interface {
+	Post(url string, contentType string, body io.Reader) (resp *http.Response, err error)
 }

--- a/types.go
+++ b/types.go
@@ -321,6 +321,6 @@ func (proxy *proxyBlockWithoutTransactions) toBlock() Block {
 	return block
 }
 
-type httpClient interface {
+type HttpClient interface {
 	Post(url string, contentType string, body io.Reader) (resp *http.Response, err error)
 }


### PR DESCRIPTION
In most cases, using http.Client is not a problem.
However, you need to explicitly specify http.Client in certain cases (for example, when running on the Google App Engine).
With this change, you can use any http.Client.