### PR TITLE
fix: BigToHex handles 0 as 0x0

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -32,5 +32,9 @@ func IntToHex(i int) string {
 
 // BigToHex covert big.Int to hexadecimal representation
 func BigToHex(bigInt big.Int) string {
-	return "0x" + strings.TrimPrefix(fmt.Sprintf("%x", bigInt.Bytes()), "0")
+	if bigInt.Cmp(big.NewInt(0)) == 0 {
+		return "0x0"
+	} else {
+		return "0x" + strings.TrimPrefix(fmt.Sprintf("%x", bigInt.Bytes()), "0")
+	}
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -45,4 +45,7 @@ func TestBigToHex(t *testing.T) {
 
 	i2, _ := big.NewInt(0).SetString("100000000000000000000", 10)
 	assert.Equal(t, "0x56bc75e2d63100000", BigToHex(*i2))
+
+	i3, _ := big.NewInt(0).SetString("0", 10)
+	assert.Equal(t, "0x0", BigToHex(*i3))
 }


### PR DESCRIPTION
Quorum requires that one can set the gas price to 0. BigToHex was converting 0 into 0x instead of 0x0. Quick fix with a test.