### PR TITLE
Fix query balance of contract token

### DIFF
--- a/types.go
+++ b/types.go
@@ -42,9 +42,9 @@ type T struct {
 // MarshalJSON implements the json.Unmarshaler interface.
 func (t T) MarshalJSON() ([]byte, error) {
 	params := map[string]interface{}{}
-    if t.From != "" {
-        params["from"] = t.From
-    }
+	if t.From != "" {
+		params["from"] = t.From
+	}
 	if t.To != "" {
 		params["to"] = t.To
 	}

--- a/types.go
+++ b/types.go
@@ -41,9 +41,10 @@ type T struct {
 
 // MarshalJSON implements the json.Unmarshaler interface.
 func (t T) MarshalJSON() ([]byte, error) {
-	params := map[string]interface{}{
-		"from": t.From,
-	}
+	params := map[string]interface{}{}
+    if t.From != "" {
+        params["from"] = t.From
+    }
 	if t.To != "" {
 		params["to"] = t.To
 	}


### PR DESCRIPTION
when I try use
```
client.EthCall(ethrpc.T{
            To:   contractAddress,
            Data: data,
        }, "latest")
```
to query balance of erc20 token
```
type T struct {
	From     string
	To       string
	Gas      int
	GasPrice *big.Int
	Value    *big.Int
	Data     string
	Nonce    int
}
```

```
func (t T) MarshalJSON() ([]byte, error) {
	params := map[string]interface{}{
		"from": t.From,
	}
	if t.To != "" {
		params["to"] = t.To
	}
	if t.Gas > 0 {
		params["gas"] = IntToHex(t.Gas)
	}
	if t.GasPrice != nil {
		params["gasPrice"] = BigToHex(*t.GasPrice)
	}
	if t.Value != nil {
		params["value"] = BigToHex(*t.Value)
	}
	if t.Data != "" {
		params["data"] = t.Data
	}
	if t.Nonce > 0 {
		params["nonce"] = IntToHex(t.Nonce)
	}

	return json.Marshal(params)
}
```
this let t.From = "" and get this json string {"id":1,"jsonrpc":"2.0","method":"eth_call","params":[{"data":"0x70a08231000000000000000000000000fe2e424e2ef9b929157dd525c414f4b128ee1bfb","from":"","to":"0xf4c90e18727c5c76499ea6369c856a6d61d3e92e"},"latest"]} after marshal

finnal error appear
```
invalid argument 0: hex string has length 0, want 40 for common.Address
```