### PR TITLE
Make From param optional in Transaction object

### DIFF
--- a/ethrpc_test.go
+++ b/ethrpc_test.go
@@ -526,10 +526,7 @@ func (s *EthRPCTestSuite) TestSendTransaction() {
 	httpmock.Reset()
 	s.registerResponse(fmt.Sprintf(`"%s"`, result), func(body []byte) {
 		s.methodEqual(body, "eth_sendTransaction")
-		s.paramsEqual(body, `[{
-			"from": ""
-		}]`)
-
+		s.paramsEqual(body,`[{}]`)
 	})
 
 	txid, err = s.rpc.EthSendTransaction(t)

--- a/types.go
+++ b/types.go
@@ -41,11 +41,12 @@ type T struct {
 
 // MarshalJSON implements the json.Unmarshaler interface.
 func (t T) MarshalJSON() ([]byte, error) {
-	params := map[string]interface{}{
-		"from": t.From,
-	}
+	params := map[string]interface{}{}
 	if t.To != "" {
 		params["to"] = t.To
+	}
+	if t.From != "" {
+		params["from"] = t.From
 	}
 	if t.Gas > 0 {
 		params["gas"] = IntToHex(t.Gas)


### PR DESCRIPTION
In [eth_call](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_call) the `from` field is optional (unlike for instance in [eth_sendTransaction](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sendtransaction)).

However, the current code always fills in the `from` field with an empty string if no actual value is provided, which results in the following error:

`invalid argument 0: hex string has length 0, want 40 for common.Address`

when using `eth_call` with no `from` field provided.

This fix makes the `from` field optional so that the rpc json request gets correctly serialized.

